### PR TITLE
feat: support dockerizing to github repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /usr/src/app
 
@@ -10,7 +10,12 @@ COPY . .
 
 RUN npm run build
 
-FROM node:20-slim
+
+FROM node:20-alpine
+
+# install tini - to make sure there's init process to cleanup node app
+RUN apk add --no-cache tini
+ENTRYPOINT [ "/sbin/tini", "--" ]
 
 WORKDIR /usr/src/app
 
@@ -24,4 +29,4 @@ EXPOSE 7531
 
 ENV NODE_ENV=production
 
-CMD ["npm", "start"] 
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ Server is running on port 7531
 
 ## Running with Docker
 
+### Pulling from latest available image
+
+```bash
+docker run -p 7531:7531 \
+  -e TEMPORAL_API_KEY=your-api-key \
+  -e TEMPORAL_ENDPOINT=your-endpoint \
+  ghcr.io/itaisoudry/temporal-flow-server:main
+```
+
+
 ### Build the Docker Image
 
 ```bash

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from "express";
 import Temporal from "./temporal.service";
-import { NotFoundException, InternalServerError } from "./excpetions";
+import { NotFoundException } from "./excpetions";
 
 const PORT = 7531; // Uncommon port number
 

--- a/src/temporal.service.ts
+++ b/src/temporal.service.ts
@@ -19,11 +19,11 @@ export default class TemporalService {
     this.endpoint = process.env.TEMPORAL_ENDPOINT ?? "";
 
     if (!this.apiKey) {
-      throw new Error("Temporal API Key is required");
+      throw new Error("Temporal API Key is required - set TEMPORAL_API_KEY envvar");
     }
 
     if (!this.endpoint) {
-      throw new Error("Temporal Endpoint is required");
+      throw new Error("Temporal Endpoint is required - set TEMPORAL_ENDPOINT envvar");
     }
 
     this.headers = {


### PR DESCRIPTION
- Added support for CD to github packages repo
- Added tini - to fix `ctrl + c` broken (missing init process in docker) - I've used tini instead of the `--init` flag - so you could later on use the same image for k8s.
- Changed image to be alpine based - to save some more MB :P
- Added some more explicit instructions for missing env vars

See example for github packages here:
https://github.com/IamShobe/temporal-flow-server/pkgs/container/temporal-flow-server


Pulling is possible using:
```
docker run -e TEMPORAL_API_KEY="test" -e TEMPORAL_ENDPOINT="endpoint" --rm docker pull ghcr.io/itaisoudry/temporal-flow-server:main
```

later on it's recommended to have proper github releases :)